### PR TITLE
Update DbFetcher.js to adjust to newer db-hafas changes

### DIFF
--- a/DbFetcher.js
+++ b/DbFetcher.js
@@ -1,5 +1,6 @@
 "use strict";
-const dbClient = require('db-hafas');
+const createClient = require('db-hafas');
+const dbClient = createClient('MagicMirror-Module/Coburn84');
 
 let DbFetcher = function (config) {
     this.config = config;
@@ -67,7 +68,7 @@ DbFetcher.prototype.processData = function (data) {
 	for (let row of data) {
 
         //if (!this.config.ignoredStations.includes(row.station.id)) {
-        if (!this.config.ignoredStations.includes(row.station.id) && this.config.excludedTransportationTypes.search(row.line.mode) == -1) {
+        if (!this.config.ignoredStations.includes(row.stop.id) && this.config.excludedTransportationTypes.search(row.line.mode) == -1) {
             //console.log('Parsing: ' + row.line.name + ' nach ' + row.direction + ' um ' + row.when);
 
             let delay = row.delay;
@@ -163,7 +164,7 @@ function printDeparture(row) {
 
     let time = row.when.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
 
-    console.log(time + " " + delayMinutes + " " + row.product.type.unicode + " " + row.direction + " | stationId: " + row.station.id);
+    console.log(time + " " + delayMinutes + " " + row.product.type.unicode + " " + row.direction + " | stopId: " + row.stop.id);
 }
 
 module.exports = DbFetcher;


### PR DESCRIPTION
Hi,
as I installed the module on my MM instance, I noticed that the original code seems to be outdated in two points: the usage of dbClient (or rather the instantiation) and the renamed station attribute that now is stop.
With the changes in this PR, the code seems to work again almost (aside from the bluebird dependency, see the other PR) flawlessly.
Thanks for your continued work on this!