### PR TITLE
Add support for canceled trains

### DIFF
--- a/DbFetcher.js
+++ b/DbFetcher.js
@@ -91,10 +91,13 @@ DbFetcher.prototype.processData = function (data) {
                 //type: productType.type,
                 type: row.line.product,
                 color: productType.color,
-                direction: row.direction
+                direction: row.direction,
+                canceled: row.canceled ? row.canceled : false
             };
 
-            //console.log(current);
+            if (current.canceled) {
+                current.when = row.scheduledWhen;
+            }
 
             departuresData.departuresArray.push(current);
         }

--- a/MMM-PublicTransportDB.js
+++ b/MMM-PublicTransportDB.js
@@ -235,7 +235,16 @@ Module.register("MMM-PublicTransportDB", {
         let row = document.createElement("tr");
 
         let timeCell = document.createElement("td");
-        timeCell.className = "centeredTd timeCell bright";
+        timeCell.className = "centeredTd timeCell";
+
+        if (current.canceled) {
+            timeCell.className += " canceled";
+        } else {
+            timeCell.className += " bright";
+        }
+
+        // in this module, currentWhen also has the time if the api returned it as "formerScheduledWhen"
+
         timeCell.innerHTML = currentWhen.format("HH:mm");
         row.appendChild(timeCell);
 

--- a/style.css
+++ b/style.css
@@ -28,6 +28,11 @@
     width: 1em;
 }
 
+.canceled {
+    color: red;
+    text-decoration: line-through;
+}
+
 .delayTimeCell {
     font-size: 16px;
     padding-left: 3px;


### PR DESCRIPTION
The current code doesn't seem to recognize canceled trains, there is just an entry "Invalid time" that is always at the beginning of the list.
This pull request should fix their sorting and format their time as red and strikethrough.